### PR TITLE
fix: bug that wasnt passing the correct namespace in kubectl alias

### DIFF
--- a/kube-scheduler-healthcheck
+++ b/kube-scheduler-healthcheck
@@ -32,7 +32,7 @@ spec:
     image: ${TEST_POD_IMAGE}
 endOfPodDef
 
-alias kubectl="timeout -t 30 kubectl --namespace \${TEST_POD_NAMESPACE}"
+alias kubectl="timeout -t 30 kubectl --namespace ${TEST_POD_NAMESPACE}"
 function create-test-pod {
   kubectl create -f /tmp/pod.yaml
 }


### PR DESCRIPTION
Discovered this while trying to pass a neew namespace with env var