### PR TITLE
fix: Replace alias with variable 

### DIFF
--- a/kube-scheduler-healthcheck
+++ b/kube-scheduler-healthcheck
@@ -32,17 +32,17 @@ spec:
     image: ${TEST_POD_IMAGE}
 endOfPodDef
 
-alias kubectl="timeout -t 30 kubectl --namespace \${TEST_POD_NAMESPACE}"
+kubectl_timeout="timeout -t 30 kubectl --namespace \${TEST_POD_NAMESPACE}"
 function create-test-pod {
-  kubectl create -f /tmp/pod.yaml
+  ${kubectl_timeout} create -f /tmp/pod.yaml
 }
 function get-test-pod {
-  if kubectl get pod ${TEST_POD_NAME} "$@" 2>/dev/null; then
+  if ${kubectl_timeout} get pod ${TEST_POD_NAME} "$@" 2>/dev/null; then
     >&2 echo "found test pod"
   fi
 }
 function delete-test-pod {
-  kubectl delete pod ${TEST_POD_NAME} --grace-period=0 "$@" 2>/dev/null
+  ${kubectl_timeout} delete pod ${TEST_POD_NAME} --grace-period=0 "$@" 2>/dev/null
 }
 
 echo "clearing old state"


### PR DESCRIPTION
This means the timeout code is actually executed, and the namespace is respected