### PR TITLE
fix: set antiaffinity on healthcheck pods

### DIFF
--- a/kube-scheduler-healthcheck
+++ b/kube-scheduler-healthcheck
@@ -32,6 +32,16 @@ metadata:
     name: ${mypodname}
     uid: ${mypoduid}
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - scheduler-healthcheck-test-pod
+        topologyKey: failure-domain.beta.kubernetes.io/zone
   containers:
   - name: pause
     image: ${TEST_POD_IMAGE}


### PR DESCRIPTION
set antiaffinity to stop healthcheck pods all failing to be torn down on the same unhealthy node